### PR TITLE
Max column width applies to auto-size only, not manual resize

### DIFF
--- a/out/csv.js
+++ b/out/csv.js
@@ -17,6 +17,17 @@ var contextMenuEl = null;
 // Defensive timeout — hides overlay if content never arrives
 var _hideTimer = null;
 
+function capColumnWidths(api, maxColumnWidth) {
+    var maxW = maxColumnWidth != null ? maxColumnWidth : 300;
+    var cols = api.getColumns();
+    if (!cols) return;
+    var updates = [];
+    cols.forEach(function(col) {
+        if (col.getActualWidth() > maxW) updates.push({ key: col.getId(), newWidth: maxW });
+    });
+    if (updates.length > 0) api.setColumnWidths(updates);
+}
+
 function hideContextMenu() {
     if (contextMenuEl) contextMenuEl.style.display = 'none';
 }
@@ -438,7 +449,6 @@ function initPage() {
             resizable: true,
             editable: options.customEditor,
             minWidth: 40,
-            maxWidth: options.maxColumnWidth != null ? options.maxColumnWidth : 300,
             suppressMovable: true,
             cellRenderer: HighlightCellRenderer,
             wrapText: !!options.wrapText,
@@ -497,11 +507,15 @@ function initPage() {
             var resize = options.resizeColumns;
             if (resize === 'all') {
                 gridApi.autoSizeAllColumns();
+                capColumnWidths(gridApi, options.maxColumnWidth);
             } else if (resize === 'first') {
                 var cols = gridApi.getColumns();
                 if (cols && cols.length > 0) {
                     var first = lineNumColDef ? cols[1] : cols[0];
-                    if (first) gridApi.autoSizeColumns([first.getId()]);
+                    if (first) {
+                        gridApi.autoSizeColumns([first.getId()]);
+                        capColumnWidths(gridApi, options.maxColumnWidth);
+                    }
                 }
             }
         },

--- a/out/excel.js
+++ b/out/excel.js
@@ -6,6 +6,17 @@ var currentSheetIndex = 0;
 var undoStack = [];
 var redoStack = [];
 
+function capColumnWidths(api, maxColumnWidth) {
+    var maxW = maxColumnWidth != null ? maxColumnWidth : 300;
+    var cols = api.getColumns();
+    if (!cols) return;
+    var updates = [];
+    cols.forEach(function(col) {
+        if (col.getActualWidth() > maxW) updates.push({ key: col.getId(), newWidth: maxW });
+    });
+    if (updates.length > 0) api.setColumnWidths(updates);
+}
+
 function getBinding(n) {
     var h1 = Math.floor(n / 26);
     var h2 = n % 26;
@@ -124,7 +135,10 @@ function loadSheet(index) {
 
     updateTabs();
     setTimeout(function() {
-        if (result.colDefs.length > 0) gridApi.autoSizeAllColumns();
+        if (result.colDefs.length > 0) {
+            gridApi.autoSizeAllColumns();
+            capColumnWidths(gridApi, options.maxColumnWidth);
+        }
     }, 50);
 }
 
@@ -188,8 +202,7 @@ function initPage() {
             filter: true,
             resizable: true,
             editable: options.customEditor,
-            minWidth: 40,
-            maxWidth: options.maxColumnWidth != null ? options.maxColumnWidth : 300
+            minWidth: 40
         },
         rowHeight: 28,
         suppressScrollOnNewData: true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "csv-excel-viewer",
     "displayName": "CSV & Excel Viewer",
     "description": "Preview CSV files and Excel spreadsheets in Visual Studio Code using AG Grid Community and SheetJS — no license required.",
-    "version": "1.8.8",
+    "version": "1.8.9",
     "icon": "img/csv-excel-viewer.png",
     "publisher": "Development42",
     "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
## What changed

- Removed `maxWidth` from `defaultColDef` in both `out/csv.js` and `out/excel.js`
- Added `capColumnWidths()` helper that clamps column widths to `maxColumnWidth` immediately after `autoSizeAllColumns()` / `autoSizeColumns()` calls

## Why

Previously `maxWidth` in `defaultColDef` was enforced by AG Grid on all resize operations, including manual drag. This prevented users from widening columns beyond the configured limit even when they explicitly wanted to.

The intended behaviour is: auto-sizing should not produce columns wider than `maxColumnWidth`, but users should be able to drag past that limit freely.

## Reviewer notes

- `capColumnWidths` defaults to 300px when `options.maxColumnWidth` is null/undefined, matching the old default
- No change to settings schema or extension host code — purely webview-side